### PR TITLE
inject new squashfs into pak file, add startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,45 @@ There's something broken within dropbear's key initial exchange (causing a segfa
 might need to login using `ssh -oHostKeyAlgorithms=ssh-rsa root@ipaddress`
 for the very first time. I don't have time to debug this odd behaviour.
 
+### Create new firmware update file with the modified rootfs
+It is possible to now create a new firmware image file with this new rootfs which can be uploaded to the camera using the UI.
+A known issue is that this only works if the original firmware image file has  new version designation thet the one running on the camera. 
+I have not been able to _reflash_ an image file using the UI, and the updater will refuse to flash the same version again.
+ 
+With [unpack-novatek-firmware.pl](unpack-novatek-firmware.pl) one can now inject the new rootfs image file into a copy of the original 
+firware update (.pak) file:
+
+``./unpack-novatek-firmware.pl -i mtdblock6-NEW.bin IPC_51516M5M.65_20071000.RLC-410-5MP.OV05A10.5MP.REOLINK.pak``
+
+The `-i` parameter takes the filename of the modified rootfs image, here `mtdblock6-NEW.bin`. The specify the original firmware (pak) file. 
+A new filename will be automartically generated, as the updater on these cameras (also) parses the filename to identify the version of 
+the image.
+Example output:
+```
+...
+Going to inject the file 'mtdblock6-NEW.bin' into the image 'IPC_51516M5M.65_20071000.RLC-410-5MP.OV05A10.5MP.REOLINK.pak'
+ the output file will be named 'IPC_51516M5M.65_20071001.RLC-410-5MP.OV05A10.5MP.REOLINK.pak'
+ cancel now if this is not desired or press enter
+
+...
+
+Image File Section  6    name: fs
+Image File Section  6 version: v1.0.0.1
+Image File Section  6  offset:  5164017
+Image File Section  6  length:  7512064
+this is the filesystem part that we want to replace
+ read 7077888 bytes from newimage 'mtdblock6-NEW.bin' to var newimagedata
+ the old fs image had 7512064 (0x72A000)(00a07200) bytes, the new one has 7077888 (0x6
+C0000)(00006c00) bytes
+ Combining the first 0x4EC5E1 bytes from the original image
+ with the contents of the new input file
+the new CRC would be: 1ff31200
+Writing output file 'IPC_51516M5M.65_20071001.RLC-410-5MP.OV05A10.5MP.REOLINK.pak'
+
+...
+
+```
+
 Enjoy logging in to your camera with SSH.
 
 ### Firmware versions

--- a/mmcscript/S99zz_ssd_script
+++ b/mmcscript/S99zz_ssd_script
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# start a script from the ssd card, so we are flexible and can add new code changes during runtime
+# we need the environment variables here, as these are not defined when this script stats
+export LD_LIBRARY_PATH='/lib:/usr/local/lib:/usr/lib:/mnt/app'
+export PATH='/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/bin:/sbin'
+export SHELL='/bin/sh'
+
+echo "Trying to start /mnt/sda/ssd_script.sh through /bin/ssd_caller_script.sh"
+/bin/ssd_caller_script.sh & 

--- a/mmcscript/nginx.conf
+++ b/mmcscript/nginx.conf
@@ -1,0 +1,161 @@
+user  root root;
+worker_processes  1;
+error_log  stderr crit;
+pid        run/nginx.pid;
+#rtmp_auto_push on;
+
+
+events 
+{
+    worker_connections  1024;
+}
+
+rtmp 
+{
+    server 
+    {
+        listen 1935;
+        application vod 
+        {
+            play /mnt/sda/;
+	    #on_play http://127.0.0.1:80/api.cgi?rtmp=auth;
+            on_play http://127.0.0.1:80/api.cgi?rtmp=start;
+            on_play_done http://127.0.0.1:80/api.cgi?rtmp=stop;
+            #record video;
+            #record_path /tmp;
+            #record_max_size 128K;
+            #record_interval 30s;
+            #record_suffix .this.is.flv;
+
+            #on_publish http://localhost:8080/publish;
+            #on_play http://localhost:8080/play;
+            #on_record_done http://localhost:8080/record_done;			
+        }
+        application live 
+        {
+            live on;
+            on_play http://127.0.0.1:80/api.cgi?rtmp=start;
+            on_play_done http://127.0.0.1:80/api.cgi?rtmp=stop;
+#            record video;
+#            record_path /mnt/app/www/;
+#            record_suffix -%d-%b-%y-%T.flv;
+        }
+        application bcs 
+        {
+            play /mnt/app/www/;
+            #on_play http://127.0.0.1:80/api.cgi?rtmp=auth;
+            on_play http://127.0.0.1:80/api.cgi?rtmp=start;
+            on_play_done http://127.0.0.1:80/api.cgi?rtmp=stop;
+            #record video;
+            #record_path /tmp;
+            #record_max_size 128K;
+            #record_interval 30s;
+            #record_suffix .this.is.flv;
+
+            #on_publish http://localhost:8080/publish;
+            #on_play http://localhost:8080/play;
+            #on_record_done http://localhost:8080/record_done;			
+        }
+
+    }
+}
+
+http 
+{
+
+    include	   mime.types;
+    default_type  application/octet-stream;
+    client_max_body_size 32M;
+    client_body_buffer_size 8k;
+    client_body_temp_path /mnt/tmp;
+    access_log  off;
+    sendfile on;
+    limit_conn_zone $binary_remote_addr zone=one:1m;
+    add_header X-Frame-Options "SAMEORIGIN";
+    #add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+    add_header X-XSS-Protection "1; mode=block"; 
+    add_header X-Content-Type-Options "nosniff";
+	server_tokens off;
+	
+    server 
+    {
+        listen      80;
+        root /mnt/app/www/;
+        index index.php index.htm index.html;
+
+        location /downloadfile/ {
+            internal;
+            limit_conn one 1;
+            limit_rate 1024k;
+            alias /mnt/sda/;
+        }
+
+### start modification
+        location /sd 
+        {
+            autoindex on;
+            alias /mnt/sda/;
+        }
+        
+        location /sdjson 
+        {
+            autoindex on;
+            alias /mnt/sda/;
+            autoindex_format jsonp;
+        }
+### end modification
+
+        location /stat 
+        {
+            rtmp_stat all;
+            rtmp_stat_stylesheet stat.xsl;
+        }
+
+        location /stat.xsl {
+            root /mnt/app/www/;
+        }
+        
+        location /control 
+        {
+            rtmp_control all;
+        }
+        location ~ .*\.cgi$ 
+        {
+            fastcgi_read_timeout 150;
+            fastcgi_pass 127.0.0.1:9527;
+            fastcgi_index index.cgi;
+            include /mnt/app/www/conf/fastcgi_params;
+        }
+    }
+    
+    server
+    {
+        listen 443;
+        root /mnt/app/www/;
+        index index.php index.htm index.html;
+        
+        ssl on;
+        ssl_protocols     TLSv1.2;
+        ssl_certificate /mnt/app/www/self.crt;
+        ssl_certificate_key /mnt/app/www/self.key;
+        
+        location /downloadfile/ {
+            internal;
+            limit_conn one 1;
+            limit_rate 1024k;
+            alias /mnt/sda/;
+        }
+		
+        location /control 
+        {
+            rtmp_control all;
+        }
+        location ~ .*\.cgi$ 
+        {
+            fastcgi_read_timeout 150;
+            fastcgi_pass 127.0.0.1:9527;
+            fastcgi_index index.cgi;
+            include /mnt/app/www/conf/fastcgi_params;
+        }	
+    }
+}

--- a/mmcscript/nginx_update.sh
+++ b/mmcscript/nginx_update.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# an example script that can be used with the ssd_script.sh on the sd card
+# it overwrites the nginx config file and reloads nginx to pick up the changes
+
+echo " adding updating nginx.conf"
+cp /mnt/sda/script/nginx.conf /mnt/tmp/nginx.conf
+echo " copied nginx.conf from /mnt/sda/script/nginx.conf to /mnt/tmp/nginx.conf"
+/bin/nginx -s reload -c /mnt/tmp/nginx.conf -p /mnt/tmp/
+echo " told nginx to reload config"

--- a/mmcscript/ssd_caller_script.sh
+++ b/mmcscript/ssd_caller_script.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# This is the caller script that tries to start /mnt/sda/ssd_script.sh every 3 seconds until it suceeeds
+# as the mmc doesn't seem to be mounted when the init scripts are run
+SSDSCRIPT=/mnt/sda/script/ssd_script.sh
+for i in $(seq 1 21); do 
+    echo "Try number $i to start ${SSDSCRIPT}"
+    nowstring=$(date)
+    echo "At ${nowstring} the mount table is:"
+    mount
+    if [ -f "$SSDSCRIPT" ]; then
+        echo "$SSDSCRIPT exists."
+        chmod 0777 ${SSDSCRIPT}
+        echo "Calling ${SSDSCRIPT}h"
+        ${SSDSCRIPT} &
+        echo "Successfully started ${SSDSCRIPT}, done"
+        exit 0
+    fi
+    echo "$SSDSCRIPT does not exist, sleeping 3 secs"
+    echo ""
+    sleep 3
+done

--- a/mmcscript/ssd_script.sh
+++ b/mmcscript/ssd_script.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Starting this script from ssd card to allow runtime changes without re-flashing.
+# It can used for all sorts of things, e.g. modifying nginx config, kill processes and
+# replace them with other binaries from sd card
+
+# please place this file on the mcc card, in a folder called scripts.
+# during runtime it will be available as /mnt/sda/script/ssd_script.sh
+
+
+echo "Starting ssd_script.sh from mmc card"
+
+echo "  ssd_script.sh: Nothing to do today"
+# add your code here
+
+#example:
+# echo " updating nginx.conf"
+# /mnt/sda/script/nginx_update.sh
+
+echo "Finished ssd_script.sh from mmc card"


### PR DESCRIPTION
Add two features:
1. The unpack-novatek-firmware.pl  gets a new -i parameter. With it will inject a new squashfs image into an existing pak firmware update file, so it can be deployed via the web UI, without serial console
2. The repack-reolink-rootfs.sh script now also plant's a startup script that allows to run any commands and scripts from an sd card directory. This allows to make chanhges to the runtime without re-flashing. An example is included where the nginx config is changed to list the directory contents of the sd card an the recordings un html and json